### PR TITLE
BUG/MEDIUM: otel: release the variable-name copy that vars_check_arg() allocates

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -54,6 +54,15 @@ int flt_otel_var_register_byname(const char *name, char **err)
 		else
 			FLT_OTEL_ERR("failed to register variable '%s'", var_name);
 	} else {
+		/*
+		 * Release the name copy vars_check_arg() left in the
+		 * descriptor; var_set() stores its own.
+		 */
+		if ((arg.type == ARGT_VAR) && (arg.data.var.flags & VDF_NAME_ALLOCATED)) {
+			ha_free((char **)&(arg.data.var.name));
+			arg.data.var.name = NULL;
+		}
+
 		OTELC_DBG(DEBUG, "variable '%s' registered", var_name);
 
 		retval = FLT_OTEL_RET_OK;


### PR DESCRIPTION
## The leak

`flt_otel_var_register_byname()` builds a stack-local `struct arg` and calls HAProxy's `vars_check_arg()`, which (since HAProxy 3.4) duplicates the variable name into the returned descriptor:

```c
/* haproxy src/vars.c, vars_check_arg() */
saved_name = my_strndup(desc.name, desc.name_len);
...
desc.flags |= VDF_NAME_ALLOCATED;
```

The descriptor owner is expected to release that copy (`VDF_NAME_ALLOCATED` — "Set if name was allocated and must be freed"), but the filter discards the converted `arg` on return without releasing it. Since `flt_otel_runtime_context_init()` registers `sess.otel.uuid` on **every stream attach**, each request leaks one name copy; variable context injection (`context ... vars`) leaks one more per injected key.

On a production edge farm (~500 req/s) this measured **~35 bytes per HTTP request ≈ 1.25 GiB/day of anonymous memory** (a 32-byte glibc chunk for the `sess.otel.uuid` copy), entirely outside HAProxy's pools (`PoolAlloc_MB` stayed at 9 while the worker grew to 7.5 GiB), until the worker was OOM-killed. Reproduced identically on the filter at `8e71674` and at v2.1.0, with HAProxy 3.4.0 and 3.4.3.

LeakSanitizer (`LD_PRELOAD=liblsan.so.0` on the real binary under wrk load, ~85k requests → 2.97 MB in 297k allocations, all on this one stack):

```
Direct leak of 202800 byte(s) in 20280 object(s) allocated from:
    #0 malloc
    #1 my_strndup src/tools.c:3044
    #2 vars_check_arg src/vars.c:840
    #3 flt_otel_var_register_byname src/vars.c:51
    #4 flt_otel_var_register src/vars.c:1262
    #5 flt_otel_runtime_context_init src/scope.c:60
    #6 flt_otel_ops_attach src/filter.c:1506
    #7 flt_stream_add_filter src/filters.c:597
    #8 flt_stream_init src/filters.c:653
    #9 stream_new src/stream.c:564
    ...
```

## Minimal reproduction

Any HTTP proxy with the filter and at least one variable registration, e.g.:

```
    otel-scope frontend_http_request
        span "HAProxy session" root
        set-var-ctx txn.trace_id "HAProxy session" trace-id
        otel-event on-frontend-http-request
```

Drive it with `wrk` and watch `Anonymous:` in `/proc/<worker>/smaps_rollup` grow linearly with the request count, or run the worker under LeakSanitizer as above.

## The fix

Release the allocated name after a successful `vars_check_arg()`. This is safe for every scope: `var_set()` duplicates the name again into the stored variable (`var->name = my_strndup(desc->name, ...)`) and `struct var_desc` documents `name` as "(not owned)" — nothing retains the pointer being freed.

With the fix, the same wrk load shows no per-request growth (measured flat over 16M requests; a production hour at ~870 req/s showed zero worker-anon growth over 3.1M requests), and LeakSanitizer reports no filter-related leaks.
