### PR TITLE
MEDIUM: otel: fast path for non-recording (sampled-out) streams

### DIFF
--- a/include/scope.h
+++ b/include/scope.h
@@ -122,6 +122,8 @@ struct flt_otel_runtime_context {
 	bool           flag_harderr;  /* [0 1] */
 	bool           flag_disabled; /* [0 1] */
 	bool           flag_ctx_valid; /* [0 1] */
+	bool           flag_norec;    /* Root span is not recording (sampled out): fast path. */
+	struct otelc_span *root_span; /* The stream's root span (parent fallback in fast path). */
 	uint8_t        logging;       /* [0 1 3] */
 	uint           analyzers;     /* Executed channel analyzers. */
 	uint           idle_timeout;  /* Idle timeout interval in milliseconds (0 = off). */

--- a/src/event.c
+++ b/src/event.c
@@ -630,6 +630,26 @@ static int flt_otel_scope_run_span(struct stream *s, struct filter *f, struct ch
 		span->span = OTELC_OPS(conf->instr->tracer, start_span_with_options, span->id, span->ref_span, span->ref_ctx, ts_steady, ts_system, conf_span->kind, NULL, 0);
 		if (span->span == NULL)
 			OTELC_RETURN_INT(FLT_OTEL_RET_ERROR);
+
+		/*
+		 * Non-recording fast path.  The sampler decides at the root: a
+		 * root that is not recording (sampled out) means every span of
+		 * this stream will be a non-recording span whose attributes,
+		 * events and status the SDK silently discards.  Remember that
+		 * on the runtime context so the remaining scopes can skip the
+		 * sample evaluation and the creation of spans that do not take
+		 * part in context propagation (see flt_otel_scope_run()).
+		 */
+		if (conf_span->flag_root) {
+			struct flt_otel_runtime_context *rt_ctx = FLT_OTEL_RT_CTX(f->ctx);
+
+			rt_ctx->root_span = span->span;
+			if (OTELC_OPS(span->span, is_recording) == 0) {
+				OTELC_DBG(INFO, "root span '%s' is not recording: fast path enabled", span->id);
+
+				rt_ctx->flag_norec = 1;
+			}
+		}
 	}
 
 	/* Add all resolved span links to the current span. */
@@ -669,7 +689,7 @@ static int flt_otel_scope_run_span(struct stream *s, struct filter *f, struct ch
 			retval = FLT_OTEL_RET_ERROR;
 
 	/* Record exceptions on the span via the wrapper's record_exception(). */
-	if (!LIST_ISEMPTY(&(conf_span->exceptions))) {
+	if (!FLT_OTEL_RT_CTX(f->ctx)->flag_norec && !LIST_ISEMPTY(&(conf_span->exceptions))) {
 		struct flt_otel_conf_exception *conf_exc;
 
 		list_for_each_entry(conf_exc, &(conf_span->exceptions), list) {
@@ -933,7 +953,7 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 	struct flt_otel_conf_unset_var *unset_var;
 	struct timespec                 ts_now_steady, ts_now_system;
 	int                             retval = FLT_OTEL_RET_OK;
-	bool                            flag_stop = 0;
+	bool                            flag_stop = 0, norec = 0;
 
 	OTELC_FUNC("%p, %p, %p, %p, %p, %p, %u, %p:%p", s, f, chn, conf_scope, ts_steady, ts_system, dir, OTELC_DPTR_ARGS(err));
 
@@ -1078,6 +1098,21 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 		OTELC_DBG(INFO, "run span '%s' -> '%s'", conf_scope->id, conf_span->id);
 		FLT_OTEL_DBG_CONF_SPAN("run span ", conf_span);
 
+		/*
+		 * Non-recording fast path: the root span was sampled out, so
+		 * nothing produced here will ever be exported.  Spans that do
+		 * not inject a context are not created at all, and for the ones
+		 * that are (propagation must stay intact so that downstream
+		 * follows the sampling decision) no attribute, event, baggage,
+		 * link or status sample is evaluated.
+		 */
+		norec = FLT_OTEL_RT_CTX(f->ctx)->flag_norec;
+		if (norec && !conf_span->flag_root && (conf_span->ctx_id == NULL)) {
+			OTELC_DBG(DEBUG, "fast path: span '%s' skipped", conf_span->id);
+
+			continue;
+		}
+
 		flt_otel_scope_data_init(&data);
 
 		span = flt_otel_scope_span_init(f->ctx, conf_span->id, conf_span->id_len, conf_span->ref_id, conf_span->ref_id_len, dir, err);
@@ -1092,7 +1127,7 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 		 * Each link name is looked up first in the active spans, then
 		 * in the extracted contexts.
 		 */
-		if (!LIST_ISEMPTY(&(conf_span->links))) {
+		if (!norec && !LIST_ISEMPTY(&(conf_span->links))) {
 			struct flt_otel_runtime_context *rt_ctx = FLT_OTEL_RT_CTX(f->ctx);
 			struct flt_otel_conf_link       *conf_link;
 
@@ -1148,7 +1183,7 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 			}
 		}
 
-		list_for_each_entry(sample, &(conf_span->attributes), list) {
+		if (!norec) list_for_each_entry(sample, &(conf_span->attributes), list) {
 			if (flt_otel_cond_pass(sample->cond, s, dir) == 0)
 				continue;
 
@@ -1158,7 +1193,7 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 				retval = FLT_OTEL_RET_ERROR;
 		}
 
-		list_for_each_entry(sample, &(conf_span->events), list) {
+		if (!norec) list_for_each_entry(sample, &(conf_span->events), list) {
 			if (flt_otel_cond_pass(sample->cond, s, dir) == 0)
 				continue;
 
@@ -1168,7 +1203,7 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 				retval = FLT_OTEL_RET_ERROR;
 		}
 
-		list_for_each_entry(sample, &(conf_span->baggages), list) {
+		if (!norec) list_for_each_entry(sample, &(conf_span->baggages), list) {
 			if (flt_otel_cond_pass(sample->cond, s, dir) == 0)
 				continue;
 
@@ -1183,7 +1218,7 @@ int flt_otel_scope_run(struct stream *s, struct filter *f, struct channel *chn, 
 		 * defined, each gated by a condition; the first whose condition
 		 * holds is applied and the remaining lines are skipped.
 		 */
-		list_for_each_entry(sample, &(conf_span->statuses), list) {
+		if (!norec) list_for_each_entry(sample, &(conf_span->statuses), list) {
 			if (flt_otel_cond_pass(sample->cond, s, dir) == 0)
 				continue;
 

--- a/src/scope.c
+++ b/src/scope.c
@@ -204,9 +204,21 @@ struct flt_otel_scope_span *flt_otel_scope_span_init(struct flt_otel_runtime_con
 				 * regardless would silently turn it into a trace
 				 * root, which is meaningless.
 				 */
-				FLT_OTEL_ERR("cannot find referenced span/context '%s'", ref_id);
+				if (rt_ctx->flag_norec && (rt_ctx->root_span != NULL)) {
+					/*
+					 * Non-recording fast path: the parent was
+					 * skipped on purpose; hang this span off
+					 * the root so that the trace/flags it
+					 * propagates stay those of the stream.
+					 */
+					OTELC_DBG(DEBUG, "fast path: parent '%s' skipped, using root span", ref_id);
 
-				OTELC_RETURN_PTR(retptr);
+					ref_span = rt_ctx->root_span;
+				} else {
+					FLT_OTEL_ERR("cannot find referenced span/context '%s'", ref_id);
+
+					OTELC_RETURN_PTR(retptr);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

When the sampler decides not to record a trace, the root span is a non-recording span and everything attached to it is discarded by the SDK. The filter nevertheless keeps doing all of its per-scope work for the rest of the stream: it evaluates attribute/event/baggage/link/status samples, creates and finishes every child span and records exceptions. Only the export is saved, so a sampled-out stream costs almost as much as a fully recorded one.

`rate-limit` is the documented way to bound the filter's cost, and it works well for the first hop. It does not cover the sampler path, though: a stream left out by `rate-limit` emits no `traceparent` at all (downstream services start their own traces), and every downstream HAProxy that extracts a parent context with `sampled=0` goes through the non-recording path regardless of its own `rate-limit`. This PR makes that path cheap by using `is_recording`, which the C wrapper already exposes for exactly this purpose.

## Measurements

HAProxy 3.4.2, filter v2.2.0, wrapper v3.3.0, SDK 1.28.0, `nbthread 4`, `h2load --h1 -c 64 -n 100000`, loopback origin (`http-request return`), 9-span scope set with header injection.

| configuration | max req/s | vs no filter |
|---|---|---|
| no filter | 108k | 100% |
| ratio 0.0 (nothing exported) | 25.1k | 23% |
| ratio 0.1 | 22.4k | 21% |
| ratio 1.0 | 17.0k | 16% |
| **patched, ratio 0.0** | **52.3k** | 48% (2.08x) |
| **patched, ratio 0.1** | **38.2k** | 35% (1.7x) |
| patched, ratio 0.5 | 24.7k | 23% (1.3x) |
| patched, ratio 1.0 | 16.2k | unchanged (fast path not taken) |

## Changes

- `include/scope.h`: `flt_otel_runtime_context` gains `flag_norec` and `root_span`.
- `src/event.c`
  - `flt_otel_scope_run_span()`: after a root span is created, query `is_recording`; if it is not recording, set `flag_norec` and remember the root.
  - `flt_otel_scope_run()`: with `flag_norec` set, spans that do not inject a context are skipped entirely, and no attribute/event/baggage/link/status sample is evaluated for the spans that are still created; exceptions are skipped as well.
- `src/scope.c` `flt_otel_scope_span_init()`: with `flag_norec` set, a parent that was skipped resolves to the root span instead of failing.

Context propagation is preserved: injecting spans are still created (non-recording, sampled flag cleared), so `traceparent` keeps reaching downstream services and they follow the sampling decision. `finish` of a skipped span only triggers the existing debug warning. `rate-limit`, `otel-stop` and `require-context` are unaffected.

## Verification

- ratio 1.0: span trees identical to before (two HAProxy tiers, SPOAs and instrumented Go/Java applications in one trace).
- ratio 0.0: requests unaffected (including `http-after-response otel-group` scopes), downstream receives `traceparent` with `sampled=0`, the collector receives no spans.

## Remaining cost and possible follow-ups

A filter that is attached but creates no span runs at the no-filter baseline (101k), while a single non-recording root span costs about 7 µs per request (60.7k). That root span is unavoidable as long as the sampling decision is made inside `StartSpan`; `perf` attributes most of its cost to the C wrapper (span-handle table lookups, `shared_ptr` copies of Tracer/Span/Context, a `make_shared<Context>` per StartSpan) rather than to the SDK. Two follow-ups would close the remaining gap, both out of scope here:

- deciding the sampling outcome before the root span is created (a wrapper API exposing the sampler), so that sampled-out streams skip the wrapper entirely;
- injecting the root context directly instead of creating the injecting span (changes the propagated parent span id).
